### PR TITLE
add main include for wasabi targets to build cleanly

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,3 +15,7 @@ uninstalldb:
 
 version:
 	mysql -u root -p --execute="SELECT lib_mysqludf_amqp_info();"
+
+ifneq ($(MAIN_DIR),)
+-include $(MAIN_DIR)/Makefile.common
+endif


### PR DESCRIPTION
This adds a soft include when MAIN_DIR is defined at Wasabi, which in turn allows our (Wasabi's) own build targets to complete without make errors when debugging.

This is a part of three (3) PRs:

one for rabbitmq-c
one for lib_mysqludf_amqp
one for main/ with updated hash for the above